### PR TITLE
If the pattern user define in ini not match any value of scim. It's r…

### DIFF
--- a/app/Ldaplibs/Import/SCIMReader.php
+++ b/app/Ldaplibs/Import/SCIMReader.php
@@ -163,7 +163,7 @@ class SCIMReader
             Log::info($exception->getMessage());
         }
 
-        return $value;
+        return null;
     }
 
     public function updateRsource($memberId, $inputRequest, $setting)


### PR DESCRIPTION
…eturn to null instead of the original string.